### PR TITLE
Fix indentation in hello world service response example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ describe_service "hello_world" do |service|
   # OUTPUT
   service.response do |response|
     response.object do |obj|
-	    obj.string :message, :doc => "The greeting message sent back. Defaults to 'World'"
+      obj.string :message, :doc => "The greeting message sent back. Defaults to 'World'"
       obj.datetime :at, :doc => "The timestamp of when the message was dispatched"
-	  end
+    end
   end
 
   # DOCUMENTATION


### PR DESCRIPTION
Just replaced a couple tabs to make the indentation line up in the readme.
