### PR TITLE
Fix Element to stop calling undefined method "html"

### DIFF
--- a/lib/response.rb
+++ b/lib/response.rb
@@ -361,10 +361,10 @@ class WeaselDiesel
         output << "<ul>"
         properties.each do |prop|
           output << "<li><span class='label notice'>#{prop.name}</span> of type <span class='label success'>#{prop.type}</span> #{'(Can be blank or missing) ' if prop.opts && prop.opts.respond_to?(:[]) && prop.opts[:null]} "
-          output <<  prop.doc unless prop.doc.blank?
+          output <<  prop.doc unless prop.doc.nil? or prop.doc.empty?
           output << "</li>"
         end
-        arrays.each{ |arr| output << arr.html }
+        arrays.each{ |arr| output << arr.to_html }
         elements.each {|el| output << el.to_html } if elements
         output << "</ul>"
         output << "</li>" if name

--- a/spec/wsdsl_spec.rb
+++ b/spec/wsdsl_spec.rb
@@ -309,6 +309,9 @@ The most common way to use this service looks like that:
       attribute.doc.should == "comments doc"
     end
 
-  end
+    it "should emit html documention for elements" do
+      @service.response.elements.first.to_html.should be_a(String)
+    end
 
+  end
 end


### PR DESCRIPTION
Generating docs when setting a response to return embedded arrays causes an exception because Element.to_html calls ary.html which doesn't exist. This commit calls the proper to_html method.
