### PR TITLE
implementing :doc in param definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ describe_service "hello_world" do |service|
   service.disable_auth # on by default
 
   # INPUT
-  service.param.string  :name, :default => 'World'
+  service.param.string  :name, :default => 'World', :doc => "The name of the person to greet."
 
   # OUTPUT
   service.response do |response|
@@ -33,7 +33,6 @@ describe_service "hello_world" do |service|
   # DOCUMENTATION
   service.documentation do |doc|
   	doc.overall "This service provides a simple hello world implementation example."
-  	doc.param :name, "The name of the person to greet."
   	doc.example "<code>curl -I 'http://localhost:9292/hello_world?name=Matt'</code>"
  end
 
@@ -59,9 +58,15 @@ Or a more complex example using XML:
       service.params do |p|
         p.string :framework, :in => SpecOptions, :null => false, :required => true
        
-        p.datetime :timestamp, :default => Time.now
+        p.datetime :timestamp, 
+                   :default => Time.now, 
+                   :doc => "The test framework used, could be one of the two following: #{SpecOptions.join(", ")}."
+
         p.string   :alpha,     :in      => ['a', 'b', 'c']
-        p.string   :version,   :null    => false
+        p.string   :version,   
+                   :null    => false,
+                   :doc => "The version of the framework to use."
+                   
         p.integer  :num,      :minvalue => 42
         p.namespace :user do |user|
           user.integer :id, :required => :true
@@ -91,10 +96,6 @@ Or a more complex example using XML:
         doc.overall <<-DOC
          This is a test service used to test the framework.
         DOC
-        
-        # doc.params <name>, <definition>
-        doc.params :framework, "The test framework used, could be one of the two following: #{SpecOptions.join(", ")}."
-        doc.params :version, "The version of the framework to use."
         
         # doc.example <markdown text>
         doc.example <<-DOC

--- a/lib/params.rb
+++ b/lib/params.rb
@@ -24,9 +24,9 @@ class WeaselDiesel
       # @option options [Symbol] :default The default value of the param.
       # @option options [Symbol] :minvalue The minimum acceptable value.
       # @option options [Symbol] :maxvalue The maximim acceptable value.
+      # @option options [Symbol] :doc Documentation for the param.
       # @api public
       attr_reader :options
-
 
       # @param [Symbol, String] name 
       #   The param's name
@@ -36,6 +36,7 @@ class WeaselDiesel
       # @option opts [Symbol] :default The default value of the param.
       # @option opts [Symbol] :minvalue The minimum acceptable value.
       # @option opts [Symbol] :maxvalue The maximim acceptable value.
+      # @option opts [Symbol] :doc Documentation for the param.
       # @api public
       def initialize(name, opts = {})
         @name    = name
@@ -48,6 +49,14 @@ class WeaselDiesel
       # @api public
       def namespace
         @options[:space_name]
+      end
+
+      # The documentation of this Rule
+      #
+      # @return [NilClass, String]
+      # api public
+      def doc
+        @options[:doc]
       end
 
       # Converts the rule into a hash with its name and options.

--- a/lib/weasel_diesel.rb
+++ b/lib/weasel_diesel.rb
@@ -408,7 +408,17 @@ module Kernel
   def describe_service(url, &block)
     service = WeaselDiesel.new(url)
     yield service
+
+    service.defined_params.list_optional.each do |rule|
+      service.doc.param(rule.name, rule.options[:doc]) if rule.options[:doc]
+    end
+
+    service.defined_params.list_required.each do |rule|
+      service.doc.param(rule.name, rule.options[:doc]) if rule.options[:doc]
+    end
+
     WSList.add(service)
+
     service
   end
 

--- a/spec/test_services.rb
+++ b/spec/test_services.rb
@@ -10,7 +10,7 @@ describe_service "services/test.xml" do |service|
     p.datetime :timestamp, :default => Time.now
     p.string   :alpha,     :in      => ['a', 'b', 'c']
     p.string   :version,   :null    => false
-    p.integer  :num,      :minvalue => 42
+    p.integer  :num,       :minvalue => 42,            :doc => "The number to test"
 
   end
 

--- a/spec/wsdsl_spec.rb
+++ b/spec/wsdsl_spec.rb
@@ -277,8 +277,10 @@ describe WeaselDiesel do
 
     it "should have a list of params doc" do
       @doc.params_doc.should be_an_instance_of(Hash)
-      @doc.params_doc.keys.sort.should == [:framework, :version]
+      @doc.params_doc.keys.sort.should == [:framework, :num, :version]
       @doc.params_doc[:framework].should == "The test framework used, could be one of the two following: #{WeaselDieselSpecOptions.join(", ")}."
+
+      @doc.params_doc[:num].should == 'The number to test'
     end
 
     it "should allow to define namespaced params doc" do


### PR DESCRIPTION
This is the other end of mattetti/wd-sinatra#3

I know I have commit access to the repo, but I'd like someone to review before sticking it in master. Chances are that there's a better way to get that data into the documentation object.
