### PR TITLE
Added WSList.find(verb, route)

### DIFF
--- a/lib/ws_list.rb
+++ b/lib/ws_list.rb
@@ -53,6 +53,18 @@ module WSList
     @list.find{|service| service.url == url}
   end
   
+  # Returns a service based on its verb and url
+  #
+  # @param [String] verb The request method (GET, POST, PUT, DELETE)
+  # @param [String] url The url of the service you are looking for.
+  # @return [Nil, WeaselDiesel] The found service.
+  #
+  # @api public
+  def find(verb, url)
+    verb = verb.to_s.downcase.to_sym
+    @list.find{|service| service.verb == verb && service.url == url}
+  end
+  
   
 end
 

--- a/spec/test_services.rb
+++ b/spec/test_services.rb
@@ -1,4 +1,6 @@
-WeaselDieselSpecOptions = ['RSpec', 'Bacon'] # usually pulled from a model
+unless Object.const_defined?("WeaselDieselSpecOptions")
+  WeaselDieselSpecOptions = ['RSpec', 'Bacon'] # usually pulled from a model
+end
 
 describe_service "services/test.xml" do |service|
   service.formats  :xml, :json
@@ -77,6 +79,30 @@ The most common way to use this service looks like that:
     DOC
   end
 end
+
+describe_service "services/test.xml" do |service|
+  service.formats  :xml, :json
+  service.http_verb :delete
+
+  service.params do |p|
+    p.integer  :id, :doc => "id of item to be deleted"
+  end
+
+  service.response do |response|
+    response.element(:name => "player_creation_ratings") do |e|
+      e.integer  :id, :doc => "id doc"
+    end
+  end
+
+
+  service.documentation do |doc|
+    # doc.overall <markdown description text>
+    doc.overall <<-DOC
+     This deletes a test service.
+    DOC
+  end
+end
+
 
 
 describe_service "services/test_no_params.xml" do |service|

--- a/spec/ws_list_spec.rb
+++ b/spec/ws_list_spec.rb
@@ -1,0 +1,16 @@
+require File.expand_path("spec_helper", File.dirname(__FILE__))
+
+describe WSList do
+
+  it "find service by verb/route" do
+    service = WSList.find(:get, 'services/test.xml')
+    service.should_not be_nil
+    
+    service.url.should == 'services/test.xml'
+    service.verb.should == :get
+
+    service = WSList.find(:delete, 'services/test.xml')
+    service.url.should == 'services/test.xml'
+    service.verb.should == :delete
+  end
+end


### PR DESCRIPTION
I know `WSList[route]` exists but I don't think its useful - you can have two services with the same route but different verbs (`GET /people/123` & `DELETE /people/123`).

This pull request add `WSList.find`.

Ultimately I think `#[]` method could/should be removed as dangerous.
