### PR TITLE
JSON generation problems

### DIFF
--- a/lib/response.rb
+++ b/lib/response.rb
@@ -24,8 +24,8 @@ class WeaselDiesel
     # Lists all top level simple elements and array elements.
     #
     # @return [Array<WeaselDiesel::Response::Element, WeaselDiesel::Response::Array>]
-    def nodes 
-      elements + arrays
+    def nodes
+      (elements + arrays).inject({}){|hash,item| hash.merge item}
     end
 
     # Shortcut to automatically create a node of array type.

--- a/lib/response.rb
+++ b/lib/response.rb
@@ -351,8 +351,8 @@ class WeaselDiesel
       # Converts an element into a json representation
       #
       # @return [String] the element attributes formated in a json structure
-      def to_json
-        to_hash.to_json
+      def to_json(*args)
+        to_hash.to_json(*args)
       end
 
       def to_html


### PR DESCRIPTION
to_json method has to accept additional parameters. Otherwise the below mentioned exception is thrown when trying to generate a json in some cases. 

wrong number of arguments (1 for 0)
/Users/jirifabian/.rvm/gems/ruby-2.0.0-p0/gems/weasel_diesel-1.2.1/lib/response.rb:354:in `to_json'
/Users/jirifabian/.rvm/gems/ruby-2.0.0-p0/gems/weasel_diesel-1.2.1/lib/response.rb:88:in`to_json'
/Users/jirifabian/.rvm/gems/ruby-2.0.0-p0/gems/weasel_diesel-1.2.1/lib/response.rb:88:in `to_json'
