### PR TITLE
Add support for optional namespaces

### DIFF
--- a/lib/params.rb
+++ b/lib/params.rb
@@ -5,7 +5,30 @@ class WeaselDiesel
   # @see WeaselDiesel#params
   #
   # @api public
-  class Params  
+  class Params
+
+    # Namespaces have a name, and options.
+    #
+    # @api public
+    class Namespace
+      # @return [Symbol, String] name The name of the namespace.
+      # @api public
+      attr_reader :name
+
+      # @return [Boolean] :null Can this namespace be null?
+      # @api public
+      attr_reader :null
+
+      # @param [Symbol, String] name
+      #   The namespace's name
+      # @param [Hash] opts The namespace options
+      # @option opts [Boolean] :null Can this value be null?
+      # @api public
+      def initialize(name, opts={})
+        @name = name
+        @null = opts[:null] || false
+      end
+    end # of Namespace
 
     # Params usually have a few rules used to validate requests.
     # Rules are not usually initialized directly but instead via
@@ -31,17 +54,17 @@ class WeaselDiesel
       # @api public
       attr_reader :options
 
-      # @param [Symbol, String] name 
+      # @param [Symbol, String] name
       #   The param's name
       # @param [Hash] opts The rule options
       # @option opts [Symbol] :in A list of acceptable values.
       # @option opts [Symbol] :options A list of acceptable values.
       # @option opts [Symbol] :default The default value of the param.
-      # @option options [Symbol] :min_value The minimum acceptable value.
-      # @option options [Symbol] :max_value The maximum acceptable value.
-      # @option options [Symbol] :min_length The minimum acceptable string length.
-      # @option options [Symbol] :max_length The maximum acceptable string length.
-      # @option options [Boolean] :null Can this value be null?
+      # @option opts [Symbol] :min_value The minimum acceptable value.
+      # @option opts [Symbol] :max_value The maximum acceptable value.
+      # @option opts [Symbol] :min_length The minimum acceptable string length.
+      # @option opts [Symbol] :max_length The maximum acceptable string length.
+      # @option opts [Boolean] :null Can this value be null?
       # @option opts [Symbol] :doc Documentation for the param.
       # @api public
       def initialize(name, opts = {})
@@ -51,7 +74,7 @@ class WeaselDiesel
 
       # The namespace used if any
       #
-      # @return [NilClass, String]
+      # @return [NilClass, WeaselDiesel::Params::Namespace]
       # @api public
       def namespace
         @options[:space_name]
@@ -76,7 +99,7 @@ class WeaselDiesel
 
     # The namespace used if any
     #
-    # @return [String]
+    # @return [NilClass, WeaselDiesel::Params::Namespace]
     # @api public
     attr_reader :space_name
 
@@ -126,7 +149,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def string(name, options={})
       param(:string, name, options)
@@ -143,7 +166,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def integer(name, options={})
       param(:integer, name, options)
@@ -160,7 +183,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def float(name, options={})
       param(:float, name, options)
@@ -177,7 +200,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def decimal(name, options={})
       param(:decimal, name, options)
@@ -194,7 +217,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def boolean(name, options={})
       param(:boolean, name, options)
@@ -211,7 +234,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def datetime(name, options={})
       param(:datetime, name, options)
@@ -228,7 +251,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def text(name, options={})
       param(:text, name, options)
@@ -245,7 +268,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def binary(name, options={})
       param(:binary, name, options)
@@ -262,7 +285,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Array<WeaselDiesel::Params::Rule>] 
+    # @return [Array<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def array(name, options={})
       param(:array, name, options)
@@ -279,7 +302,7 @@ class WeaselDiesel
     #    service.param.string  :type, :in => LeaderboardType.names, :default => LeaderboardType::LIFETIME
     #
     # @api public
-    # @return [Arrays<WeaselDiesel::Params::Rule>] 
+    # @return [Arrays<WeaselDiesel::Params::Rule>]
     #   List of optional or required param rules depending on the new param rule type
     def file(name, options={})
       param(:file, name, options)
@@ -358,11 +381,16 @@ class WeaselDiesel
 
     # Defines a namespaced param
     #
+    # @param [Symbol, String] name
+    #   The name of the namespace
+    # @param [Hash] opts
+    #   A hash representing the namespace settings
+    #
     # @yield [Params] the newly created namespaced param
     # @return [Array<WeaselDiesel::Params>] the list of all the namespaced params
     # @api public
-    def namespace(name)
-      params = Params.new(:space_name => name)
+    def namespace(name, opts={})
+      params = Params.new(:space_name => Namespace.new(name, :null => opts[:null]))
       yield(params) if block_given?
       namespaced_params << params unless namespaced_params.include?(params)
     end
@@ -382,9 +410,10 @@ class WeaselDiesel
     # @api public
     def param_names
       first_level_expected_params = (list_required + list_optional).map{|rule| rule.name.to_s}
-      first_level_expected_params += namespaced_params.map{|r| r.space_name.to_s}
+      first_level_expected_params += namespaced_params.map{|r| r.space_name.name.to_s}
       first_level_expected_params
     end
 
   end # of Params
+
 end

--- a/lib/weasel_diesel.rb
+++ b/lib/weasel_diesel.rb
@@ -366,8 +366,8 @@ class WeaselDiesel
   # and in the documentation block.
   # @api private
   def sync_input_param_doc
-    defined_params.namespaced_params.each do |prms| 
-      doc.namespace(prms.space_name) do |ns|
+    defined_params.namespaced_params.each do |prms|
+      doc.namespace(prms.space_name.name) do |ns|
         prms.list_optional.each do |rule|
           ns.param(rule.name, rule.options[:doc]) if rule.options[:doc]
         end

--- a/spec/test_services.rb
+++ b/spec/test_services.rb
@@ -31,6 +31,10 @@ describe_service "services/test.xml" do |service|
     user.array   :skills, :in => %w{ruby java networking}
   end
 
+  service.params.namespace :options, :null => true do |option|
+    option.boolean :verbose, :default => false, :required => :true
+  end
+
   # the response contains a list of player creation ratings each object in the list
 
 =begin

--- a/spec/wd_params_spec.rb
+++ b/spec/wd_params_spec.rb
@@ -10,8 +10,8 @@ describe WeaselDiesel::Params do
 
   it "should have the possibility to have a space name" do
     @sparams.should respond_to(:space_name)
-    service_params = WeaselDiesel::Params.new(:space_name => 'spec_test')
-    service_params.space_name.should == 'spec_test'
+    service_params = WeaselDiesel::Params.new(:space_name => WeaselDiesel::Params::Namespace.new('spec_test'))
+    service_params.space_name.name.should == 'spec_test'
   end
 
   it "should have a list of required param rules" do
@@ -26,8 +26,9 @@ describe WeaselDiesel::Params do
 
   it "should have a list of namespaced param rules" do
     @sparams.namespaced_params.should be_an_instance_of(Array)
-    @sparams.namespaced_params.length.should == 1
-    @sparams.namespaced_params.first.space_name.should == :user
+    @sparams.namespaced_params.length.should == 2
+    @sparams.namespaced_params.first.space_name.name.should == :user
+    @sparams.namespaced_params[1].space_name.name.should == :options
   end
 
   it "should allow to define namespaced param" do
@@ -38,7 +39,7 @@ describe WeaselDiesel::Params do
       end
     end
     service.params.namespaced_params.should_not be_empty
-    ns = service.params.namespaced_params.find{|ns| ns.space_name == :preference}
+    ns = service.params.namespaced_params.find{|ns| ns.space_name.name == :preference}
     ns.should_not be_nil
     ns.list_optional.first.name.should == "Ze id."
   end
@@ -51,7 +52,7 @@ describe WeaselDiesel::Params do
       end
     end
     service.params.namespaced_params.should_not be_empty
-    ns = service.params.namespaced_params.find{|ns| ns.space_name == :preference}
+    ns = service.params.namespaced_params.find{|ns| ns.space_name.name == :preference}
     ns.should_not be_nil
     ns.list_optional.first.name.should == "Ze id."
   end
@@ -70,6 +71,21 @@ describe WeaselDiesel::Params do
       @rule.options[:type].should == :string
       @rule.options[:in].should ==  WeaselDieselSpecOptions
       @rule.options[:null].should be_false
+    end
+  end
+
+  describe WeaselDiesel::Params::Namespace do
+    before :all do
+      @namespace = @sparams.namespaced_params.first.space_name
+      @namespace.should_not be_nil
+    end
+
+    it "should have a name" do
+      @namespace.name.should == :user
+    end
+
+    it "should have a null attribute" do
+      @namespace.null.should be_false
     end
   end
 


### PR DESCRIPTION
This is a PR for #23. I couldn't attach this PR to that issue, so I had to create a new PR.

This is just my initial stab at it. I think my test coverage makes sense, but I don't actually need this feature, so it could definitely use a review by someone who does.

If this implementation makes sense, I'll update the documentation as well. In my implementation, I created a `WeaselDiesel::Params::Namespace` class that contains a name and options (currently, only a `null` attribute). I'm not entirely sure that the `space_name` attribute works to describe the params namespace now that it's more than just a string.

`wd-sinatra` will also probably need a patch so it can generate the correct documentation for this feature.

Let me know what you think.

FYI: Travis CI fails due to a top level array spec failing. This fails in master as well, so it shouldn't be caused by my branch.
