### PR TITLE
Problem with response.to_json

### DIFF
--- a/lib/response.rb
+++ b/lib/response.rb
@@ -153,6 +153,7 @@ class WeaselDiesel
         @type       = type
         @attributes = []
         @meta_attributes = []
+        @elements   = []
         @vectors    = []
         @key        = nil
         # we don't need to initialize the nested elements, by default they should be nil
@@ -340,11 +341,11 @@ class WeaselDiesel
       def to_hash
         attrs = {}
         attributes.each{ |attr| attrs[attr.name] = attr.type }
-        elements.each{ |el| attrs[el.name] = el.to_hash } if elements
+        (vectors + elements).each{ |el| attrs[el.name] = el.to_hash }
         if self.class == Vector
-          name ? {name => [attrs]} : [attrs]
+          [attrs]
         else
-          name ? {name => attrs} : attrs
+          attrs
         end
       end
 

--- a/lib/response.rb
+++ b/lib/response.rb
@@ -337,15 +337,16 @@ class WeaselDiesel
 
       # Converts an element into a hash representation
       #
+      # @param [Boolean] root_node true if this node has no parents.
       # @return [Hash] the element attributes formated in a hash
-      def to_hash
+      def to_hash(root_node=true)
         attrs = {}
         attributes.each{ |attr| attrs[attr.name] = attr.type }
-        (vectors + elements).each{ |el| attrs[el.name] = el.to_hash }
+        (vectors + elements).each{ |el| attrs[el.name] = el.to_hash(false) }
         if self.class == Vector
-          [attrs]
+          (root_node && name) ? {name => [attrs]} : [attrs]
         else
-          attrs
+          (root_node && name) ? {name => attrs} : attrs
         end
       end
 

--- a/lib/weasel_diesel/doc_generator/template.erb
+++ b/lib/weasel_diesel/doc_generator/template.erb
@@ -98,7 +98,7 @@
                   <% end %>
                 <% end %>
                 <h4>Example</h4>
-                <pre><%= api.response.to_json %></pre>
+                <pre><%= JSON.pretty_generate(JSON.parse(api.response.to_json)) %></pre>
               </div>
 
           </div>

--- a/spec/wd_documentation_spec.rb
+++ b/spec/wd_documentation_spec.rb
@@ -77,7 +77,9 @@ The most common way to use this service looks like that:
   it "should have a json representation of an response element" do
     json = @service.response.elements.first.to_json
     loaded_json = JSON.load(json)
-    loaded_json[@service.response.elements.first.doc.name].should_not be_empty
+    loaded_json.has_key?(@service.response.elements.first.name).should be_true
+    loaded_json[@service.response.elements.first.name].should_not be_empty
+    loaded_json[@service.response.elements.first.name].has_key?("player_creation_rating").should be_true
   end
 
   it "should have documentation for a response element attribute" do


### PR DESCRIPTION
Hi first of all nice project. 

I start using it a couple of days ago and run into an issue with the documentation generation in wd-sinatra I didn't raise the issue there cause it seems to be in the response object of Weasel-Dieasel

Here is the response definition:

``` ruby
  service.response do |response|
    response.object do |obj|
      obj.string :status, :doc => "Response status either OK or ERROR"
      obj.string :message, :doc => "The error message if an error occur", :null => true
      obj.element :name => :payload, :type => 'Resource' do |payload|
        payload.string :id, :doc => "Resource id"
        payload.string :name, :doc => "Resource name"
        payload.string :path, :doc => "Resource full path"
        payload.object :metadata, :doc => "Resource metadata"
        payload.array :tags, :doc => "Resource list of tags"
        payload.datetime :created_at, :doc => "Created at timestamp"
        payload.datetime :updated_at, :doc => "Resource updated at timestamp"
      end
    end
  end
```

And this is the JSON result of api.response.to_json

``` json
{
  "status": "string",
  "message": "string",
  "payload": {
    "payload": {
      "id": "string",
      "name": "string",
      "path": "string",
      "created_at": "datetime",
      "updated_at": "datetime",
      "metadata": {
        "metadata": {

        }
      }
    }
  }
}
```

If you look at the payload attribute it has a nested payload attribute with the actual payload attributes, thats not what I intended and maybe my declaration is wrong. 

This is what I want the payload attribute to look like:

``` json
{
  "status": "string",
  "message": "string",
  "payload": {
      "id": "string",
      "name": "string",
      "path": "string",
      "created_at": "datetime",
      "updated_at": "datetime",
      "metadata": {
        "metadata": {

        }
    }
  }
}
```
