### PR TITLE
remove SinatraServiceController#logged_in?

### DIFF
--- a/lib/framework_ext/sinatra_controller.rb
+++ b/lib/framework_ext/sinatra_controller.rb
@@ -72,9 +72,4 @@ class SinatraServiceController
   # Forwarding some methods to the underlying app object
   def_delegators :app, :settings, :halt, :compile_template, :session
 
-  # Returns true or false if the player is logged in.
-  def logged_in?
-    !session[:player_id].nil?
-  end
-
 end


### PR DESCRIPTION
This should probably just be left to the client applications to implement themselves.
